### PR TITLE
style: 탭 바 상단 구분선 제거

### DIFF
--- a/SALog/Sources/Features/MainTabBarScene/MainTabBarController.swift
+++ b/SALog/Sources/Features/MainTabBarScene/MainTabBarController.swift
@@ -52,6 +52,8 @@ final class MainTabBarController: UITabBarController {
     ) -> UINavigationController {
         let appearance = UITabBarAppearance()
         appearance.backgroundColor = .background
+        appearance.shadowImage = UIImage()
+        appearance.shadowColor = nil
 
         tabBar.standardAppearance = appearance
         tabBar.scrollEdgeAppearance = appearance


### PR DESCRIPTION
### 탭 바 상단 구분선 제거 코드
```swift
let appearance = UITabBarAppearance()
appearance.shadowImage = UIImage()
appearance.shadowColor = nil
```