### PR TITLE
feat: 내비게이션 바 버튼 추가

### DIFF
--- a/SALog/Sources/Features/ProfileScene/ProfileViewController.swift
+++ b/SALog/Sources/Features/ProfileScene/ProfileViewController.swift
@@ -7,4 +7,23 @@
 
 import UIKit
 
-final class ProfileViewController: BaseViewController {}
+final class ProfileViewController: BaseViewController {
+
+    // MARK: - Properties
+
+    private let copyButton = UIButton(type: .system)
+
+    // MARK: - UI
+
+    override func setStyle() {
+        super.setStyle()
+
+        copyButton.do {
+            $0.setImage(UIImage(systemName: "doc.on.doc"), for: .normal)
+            $0.tintColor = .black
+        }
+
+        let rightBarButton = UIBarButtonItem(customView: copyButton)
+        navigationItem.rightBarButtonItem = rightBarButton
+    }
+}


### PR DESCRIPTION
### 전체 코드
```swift
import UIKit

final class ProfileViewController: BaseViewController {

    // MARK: - Properties

    private let copyButton = UIButton(type: .system)

    // MARK: - UI

    override func setStyle() {
        super.setStyle()

        copyButton.do {
            $0.setImage(UIImage(systemName: "doc.on.doc"), for: .normal)
            $0.tintColor = .black
        }

        let rightBarButton = UIBarButtonItem(customView: copyButton)
        navigationItem.rightBarButtonItem = rightBarButton
    }
}
```

### 코드 설명
- `ProfileViewController`는 `BaseViewController`를 상속받음. 
- `super.setStyle()` 호출로 `BaseViewController`의 공통 스타일 적용됨. 
- 예를 들어, `BaseViewController`에서 배경색을 설정하면 `ProfileViewController`도 동일하게 적용받음. 

### 장점
- 중복 코드를 줄일 수 있음.
- 스타일의 일관성을 유지할 수 있음.
- 유지보수성과 확장성이 높아짐.

### 단점
- 상속 구조로 인해 `BaseViewController`의 변경이 모든 하위 클래스에 영향을 미침. -> 의존성이 강함.
- 상속이 깊어질 경우 코드의 복잡도가 증가할 수 있음.