### PR TITLE
feat: 프로필 메뉴 탭 구현

### DIFF
--- a/SALog.xcodeproj/project.pbxproj
+++ b/SALog.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		058267372D2BDA0C00218960 /* UIButton+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 058267362D2BDA0C00218960 /* UIButton+.swift */; };
 		058267392D2D096700218960 /* ProfileCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 058267382D2D096700218960 /* ProfileCell.swift */; };
 		0582673C2D2D197900218960 /* ProfileImageFullScreenView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0582673B2D2D197900218960 /* ProfileImageFullScreenView.swift */; };
+		0582673E2D2E8C0600218960 /* ProfileMenuTabCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0582673D2D2E8C0600218960 /* ProfileMenuTabCell.swift */; };
 		D02987EC61866F0C6DB665B1 /* Pods_SALog.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D8B365F2D2788EED3D56680 /* Pods_SALog.framework */; };
 /* End PBXBuildFile section */
 
@@ -53,6 +54,7 @@
 		058267362D2BDA0C00218960 /* UIButton+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+.swift"; sourceTree = "<group>"; };
 		058267382D2D096700218960 /* ProfileCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileCell.swift; sourceTree = "<group>"; };
 		0582673B2D2D197900218960 /* ProfileImageFullScreenView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileImageFullScreenView.swift; sourceTree = "<group>"; };
+		0582673D2D2E8C0600218960 /* ProfileMenuTabCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileMenuTabCell.swift; sourceTree = "<group>"; };
 		3D8B365F2D2788EED3D56680 /* Pods_SALog.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SALog.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7DBEA1788124AE2C50D1FBEB /* Pods-SALog.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SALog.release.xcconfig"; path = "Target Support Files/Pods-SALog/Pods-SALog.release.xcconfig"; sourceTree = "<group>"; };
 		DD6597661C5AF620FEB897AD /* Pods-SALog.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SALog.debug.xcconfig"; path = "Target Support Files/Pods-SALog/Pods-SALog.debug.xcconfig"; sourceTree = "<group>"; };
@@ -166,6 +168,7 @@
 			isa = PBXGroup;
 			children = (
 				058267382D2D096700218960 /* ProfileCell.swift */,
+				0582673D2D2E8C0600218960 /* ProfileMenuTabCell.swift */,
 				058266BB2D27BEAC00218960 /* ProfileViewController.swift */,
 			);
 			path = ProfileScene;
@@ -361,6 +364,7 @@
 				058266B52D27BDE800218960 /* MainTabBarController.swift in Sources */,
 				058267392D2D096700218960 /* ProfileCell.swift in Sources */,
 				058266C72D27C52000218960 /* UIStackView+.swift in Sources */,
+				0582673E2D2E8C0600218960 /* ProfileMenuTabCell.swift in Sources */,
 				058266BA2D27BE9E00218960 /* BlackListViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SALog/Sources/Features/ProfileScene/ProfileMenuTabCell.swift
+++ b/SALog/Sources/Features/ProfileScene/ProfileMenuTabCell.swift
@@ -1,0 +1,85 @@
+//
+//  ProfileMenuTabCell.swift
+//  SALog
+//
+//  Created by RAFA on 1/8/25.
+//
+
+import UIKit
+
+final class ProfileMenuTabCell: BaseCollectionReusableView {
+
+    // MARK: - Properties
+
+    private let menuStackView = UIStackView()
+    private var menuButtons: [UIButton] = []
+
+    private let menu = ["기본 정보", "맵 숙련도", "랭크전 정보", "매칭 기록"]
+    private var selectedIndex: Int = 0
+
+    // MARK: - Initializer
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        configureMenuButtons()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Actions
+
+    @objc private func handleButtonTap(_ sender: UIButton) {
+        updateSelectedButton(to: sender.tag)
+    }
+
+    // MARK: - Helpers
+
+    private func updateSelectedButton(to index: Int) {
+        menuButtons[selectedIndex].isSelected = false
+        selectedIndex = index
+        menuButtons[selectedIndex].isSelected = true
+    }
+
+    private func configureMenuButtons() {
+        for (index, title) in menu.enumerated() {
+            let button = UIButton(type: .custom)
+            button.setTitle(title, for: .normal)
+            button.setTitleColor(.black, for: .selected)
+            button.setTitleColor(.lightGray, for: .normal)
+            button.titleLabel?.font = .systemFont(ofSize: 16, weight: .medium)
+            button.tag = index
+            button.addTarget(
+                self,
+                action: #selector(handleButtonTap),
+                for: .touchUpInside
+            )
+
+            menuStackView.addArrangedSubview(button)
+            menuButtons.append(button)
+        }
+
+        updateSelectedButton(to: 0)
+    }
+
+    // MARK: - UI
+
+    override func setStyle() {
+        menuStackView.configureStackView(
+            axis: .horizontal,
+            spacing: 10
+        )
+    }
+
+    override func setHierarchy() {
+        addSubview(menuStackView)
+    }
+
+    override func setLayout() {
+        menuStackView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+}

--- a/SALog/Sources/Features/ProfileScene/ProfileViewController.swift
+++ b/SALog/Sources/Features/ProfileScene/ProfileViewController.swift
@@ -22,7 +22,7 @@ final class ProfileViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        setNavigationBarButtonItems()
+        setNavigationBarStyle()
         setDelegates()
         registerCells()
     }
@@ -43,7 +43,7 @@ final class ProfileViewController: BaseViewController {
 
     // MARK: - UI
 
-    private func setNavigationBarButtonItems() {
+    private func setNavigationBarStyle() {
         let rightBarButton = UIBarButtonItem(customView: copyButton)
         navigationItem.rightBarButtonItem = rightBarButton
     }

--- a/SALog/Sources/Features/ProfileScene/ProfileViewController.swift
+++ b/SALog/Sources/Features/ProfileScene/ProfileViewController.swift
@@ -17,6 +17,9 @@ final class ProfileViewController: BaseViewController {
         collectionViewLayout: createLayout()
     )
 
+    private let userNickname = "지올"
+    private var isTitleSet = false
+
     // MARK: - Lifecycle
 
     override func viewDidLoad() {
@@ -39,11 +42,30 @@ final class ProfileViewController: BaseViewController {
             ProfileCell.self,
             forCellWithReuseIdentifier: ProfileCell.identifier
         )
+
+        collectionView.register(
+            ProfileMenuTabCell.self,
+            forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader,
+            withReuseIdentifier: ProfileMenuTabCell.identifier
+        )
+
+        collectionView.register(
+            UICollectionViewCell.self,
+            forCellWithReuseIdentifier: "EmptyCell"
+        )
     }
 
     // MARK: - UI
 
     private func setNavigationBarStyle() {
+        let appearance = UINavigationBarAppearance()
+        appearance.backgroundColor = .background
+        appearance.shadowColor = nil
+
+        navigationController?.navigationBar.standardAppearance = appearance
+        navigationController?.navigationBar.scrollEdgeAppearance = appearance
+        navigationController?.navigationBar.isTranslucent = false
+
         let rightBarButton = UIBarButtonItem(customView: copyButton)
         navigationItem.rightBarButtonItem = rightBarButton
     }
@@ -68,29 +90,84 @@ final class ProfileViewController: BaseViewController {
     }
 }
 
+// MARK: - UIScrollViewDelegate
+
+extension ProfileViewController: UIScrollViewDelegate {
+
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        let triggerOffset: CGFloat = 200
+        let currentOffset = scrollView.contentOffset.y
+
+        if currentOffset > triggerOffset && !isTitleSet {
+            navigationItem.title = userNickname
+            isTitleSet = true
+        } else if currentOffset <= triggerOffset && isTitleSet {
+            navigationItem.title = nil
+            isTitleSet = false
+        }
+    }
+}
+
 // MARK: - UICollectionViewDataSource
 
 extension ProfileViewController: UICollectionViewDataSource {
+
+    func numberOfSections(in collectionView: UICollectionView) -> Int {
+        return 2
+    }
 
     func collectionView(
         _ collectionView: UICollectionView,
         numberOfItemsInSection section: Int
     ) -> Int {
-        return 1
+        switch section {
+        case 0: return  1
+        case 1: return 10
+        default: return 0
+        }
     }
     
     func collectionView(
         _ collectionView: UICollectionView,
         cellForItemAt indexPath: IndexPath
     ) -> UICollectionViewCell {
-        guard let cell = collectionView.dequeueReusableCell(
-            withReuseIdentifier: ProfileCell.identifier,
-            for: indexPath
-        ) as? ProfileCell else {
-            return UICollectionViewCell()
-        }
+        switch indexPath.section {
+        case 0:
+            guard let cell = collectionView.dequeueReusableCell(
+                withReuseIdentifier: ProfileCell.identifier,
+                for: indexPath
+            ) as? ProfileCell else {
+                return UICollectionViewCell()
+            }
 
-        return cell
+            return cell
+        case 1:
+            let cell = collectionView.dequeueReusableCell(
+                withReuseIdentifier: "EmptyCell",
+                for: indexPath
+            )
+            return cell
+
+        default: return UICollectionViewCell()
+        }
+    }
+
+    func collectionView(
+        _ collectionView: UICollectionView,
+        viewForSupplementaryElementOfKind kind: String,
+        at indexPath: IndexPath
+    ) -> UICollectionReusableView {
+        if kind == UICollectionView.elementKindSectionHeader && indexPath.section == 1 {
+            guard let header = collectionView.dequeueReusableSupplementaryView(
+                ofKind: kind,
+                withReuseIdentifier: ProfileMenuTabCell.identifier,
+                for: indexPath
+            ) as? ProfileMenuTabCell else {
+                return UICollectionReusableView()
+            }
+            return header
+        }
+        return UICollectionReusableView()
     }
 }
 
@@ -103,22 +180,28 @@ extension ProfileViewController: UICollectionViewDelegate {}
 private extension ProfileViewController {
 
     func createLayout() -> UICollectionViewCompositionalLayout {
-        return UICollectionViewCompositionalLayout(sectionProvider: sectionProvider)
+        return UICollectionViewCompositionalLayout { sectionIndex, environment in
+            switch sectionIndex {
+            case 0:
+                return self.createProfileSection()
+            case 1:
+                return self.createContentSection()
+            default:
+                return nil
+            }
+        }
     }
 
-    func sectionProvider(
-        sectionIndex: Int,
-        environment: NSCollectionLayoutEnvironment
-    ) -> NSCollectionLayoutSection? {
+    private func createProfileSection() -> NSCollectionLayoutSection {
         let itemSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1.0),
-            heightDimension: .estimated(300)
+            heightDimension: .fractionalHeight(1.0)
         )
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
 
         let groupSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1.0),
-            heightDimension: .estimated(300)
+            heightDimension: .estimated(200)
         )
         let group = NSCollectionLayoutGroup.vertical(
             layoutSize: groupSize,
@@ -126,6 +209,45 @@ private extension ProfileViewController {
         )
 
         let section = NSCollectionLayoutSection(group: group)
+
+        return section
+    }
+
+    private func createMenuTabSection() -> NSCollectionLayoutBoundarySupplementaryItem {
+        let headerSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .absolute(50)
+        )
+
+        let headerItem = NSCollectionLayoutBoundarySupplementaryItem(
+            layoutSize: headerSize,
+            elementKind: UICollectionView.elementKindSectionHeader,
+            alignment: .top
+        )
+
+        headerItem.pinToVisibleBounds = true
+
+        return headerItem
+    }
+
+    private func createContentSection() -> NSCollectionLayoutSection {
+        let itemSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .absolute(300)
+        )
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+
+        let groupSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .absolute(300)
+        )
+        let group = NSCollectionLayoutGroup.vertical(
+            layoutSize: groupSize,
+            subitems: [item]
+        )
+
+        let section = NSCollectionLayoutSection(group: group)
+        section.boundarySupplementaryItems = [createMenuTabSection()]
 
         return section
     }


### PR DESCRIPTION
# ProfileMenuTabCell.swift
**`updateSelectedButton(to:)`**
```swift
private func updateSelectedButton(to index: Int) {
    menuButtons[selectedIndex].isSelected = false
    selectedIndex = index
    menuButtons[selectedIndex].isSelected = true
}
```

### 코드 설명
- **역할**

    - 선택된 메뉴 버튼의 상태를 업데이트하는 메서드

    - 기존 선택된 버튼을 비활성화하고 새로 선택된 버튼을 활성화 상태로 전환

- **매개변수 `index: Int`**
    - 업데이트할 버튼의 `tag` 값 전달
    - `menuButtons` 배열에서 버튼을 식별하는 데 사용

- **동작 과정**
    1. `selectedIndex`로 저장된 이전 선택 버튼 비활성화 (`isSelected = false`)
    2. 전달받은 `index`로 현재 선택된 버튼을 업데이트
    3. 새로운 선택 버튼 활성화 (`isSelected = true`)

<br>

**`configureMenuButtons()`**
```swift
private func configureMenuButtons() {
    for (index, title) in menu.enumerated() {
        let button = UIButton(type: .custom)
        button.setTitle(title, for: .normal)
        button.setTitleColor(.black, for: .selected)
        button.setTitleColor(.lightGray, for: .normal)
        button.titleLabel?.font = .systemFont(ofSize: 16, weight: .medium)
        button.tag = index
        button.addTarget(
            self,
            action: #selector(handleButtonTap),
            for: .touchUpInside
        )

        menuStackView.addArrangedSubview(button)
        menuButtons.append(button)
    }

    updateSelectedButton(to: 0)
}
```

### 코드 설명
- **역할**
    - 메뉴에 표시될 버튼들을 동적으로 생성 후 스택 뷰에 추가
    - 초기 상태로 첫 번째 버튼을 선택 상태로 설정

- **동작 과정**
    1. `menu` 배열을 순회하며 각 메뉴 제목과 인덱스를 가져옴
    2. 새로운 `UIButton`을 생성하고 제목, 색상, 폰트 등의 스타일 설정
    3. 버튼 `tag`에 해당 `index`를 저장하여 클릭 이벤트 처리 시 식별할 수 있도록 설정
    4. `handleButtonTap` 메서드를 버튼 클릭 액션에 연결
    5. 버튼을 `menuStackView`에 추가하고 `menuButtons` 배열에도 저장
    6. `updateSelectedButton(to:)`를 호출하여 첫 번째 버튼을 기본 선택 상태로 설정

<br>

# ProfileViewController.swift
**`scrollViewDidScroll(_:)`**
```swift
func scrollViewDidScroll(_ scrollView: UIScrollView) {
    let triggerOffset: CGFloat = 200
    let currentOffset = scrollView.contentOffset.y

    if currentOffset > triggerOffset && !isTitleSet {
        navigationItem.title = userNickname
        isTitleSet = true
    } else if currentOffset <= triggerOffset && isTitleSet {
        navigationItem.title = nil
        isTitleSet = false
    }
}
```

### 코드 설명
- **역할**
    - 스크롤 위치를 기반으로 `navigationItem.title`을 동적으로 설정

- **동작 과정**
    1. `currentOffset`를 계산하여 현재 스크롤 위치를 가져옴
    2. 스크롤이 `triggerOffset(200)`보다 아래로 내려가면 `navigationItem.title`을 `userNickname`으로 설정
    3. 다시 스크롤이 위로 올라가면 `navigationItem.title`을 `nil`로 되돌림
    4. `isTitleSet` 플래그를 사용하여 중복 호출 방지

- **특징**
    - UX 관점에서 유저가 화면을 내릴 때 `navigationItem`에 닉네임을 고정 표시하여 가시성을 향상
    - 스크롤 위치에 따라 동적으로 동작하여 깔끔한 사용자 경험 제공

<br>

**`viewForSupplementaryElementOfKind(_:at:)`**
```swift
func collectionView(
    _ collectionView: UICollectionView,
    viewForSupplementaryElementOfKind kind: String,
    at indexPath: IndexPath
) -> UICollectionReusableView {
    if kind == UICollectionView.elementKindSectionHeader && indexPath.section == 1 {
        guard let header = collectionView.dequeueReusableSupplementaryView(
            ofKind: kind,
            withReuseIdentifier: ProfileMenuTabCell.identifier,
            for: indexPath
        ) as? ProfileMenuTabCell else {
            return UICollectionReusableView()
        }
        return header
    }
    return UICollectionReusableView()
}
```

### 코드 설명
- **역할**
    - 섹션 헤더에 해당하는 `ProfileMenuTabCell`을 반환하여 컬렉션 뷰의 헤더 구성

- **동작 과정**
    1. `kind`가 `UICollectionView.elementKindSectionHeader`인지 확인
    2. 섹션이 1인지 검사하고 헤더를 `ProfileMenuTabCell`로 디큐
    3. 디큐가 실패할 경우 기본 `UICollectionReusableView`를 반환

- **특징**
    - 특정 섹션에만 헤더를 제공하여 섹션별 커스터마이징 가능

<br>

**`NSCollectionLayoutBoundarySupplementaryItem`**
```swift
private func createMenuTabSection() -> NSCollectionLayoutBoundarySupplementaryItem {
    let headerSize = NSCollectionLayoutSize(
        widthDimension: .fractionalWidth(1.0),
        heightDimension: .absolute(50)
    )

    let headerItem = NSCollectionLayoutBoundarySupplementaryItem(
        layoutSize: headerSize,
        elementKind: UICollectionView.elementKindSectionHeader,
        alignment: .top
    )

    headerItem.pinToVisibleBounds = true

    return headerItem
}
```

### 코드 설명
- **역할**
    - 섹션에 고정되는 헤더 레이아웃 정의

- **동작 과정**
    1. `headerSize` - 헤더의 크기를 전체 너비와 고정 높이(50)로 정의
    2. `headerItem` - `NSCollectionLayoutBoundarySupplementaryItem`로 생성
    3. `pinToVisibleBounds` - 스크롤 시 헤더가 화면에 고정되도록 설정

- **특징**
    - 고정된 헤더를 통해 가시성 향상

<br>

### 실행 영상
| 내비게이션 바 타이틀 | 헤더 상단 고정 |
| -- | -- |
| ![Simulator Screen Recording - iPhone 16 Pro - 2025-01-09 at 21 07 36](https://github.com/user-attachments/assets/dc43d6c9-0194-4502-94b4-f55391e6ea53) | ![Simulator Screen Recording - iPhone 16 Pro - 2025-01-09 at 21 07 56](https://github.com/user-attachments/assets/9dfd0d4a-3292-482a-a2d2-859578bfe4c1) |